### PR TITLE
Automatically download CoreOS images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:23
 
 RUN dnf -y update && \
-    dnf install -y net-tools libattr libattr-devel xfsprogs bridge-utils qemu-kvm  qemu-system-x86 qemu-img && \
+    dnf install -y net-tools libattr libattr-devel xfsprogs bridge-utils qemu-kvm  qemu-system-x86 qemu-img gpg && \
     dnf clean all
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh


### PR DESCRIPTION
If COREOS_VERSION set, download images.
If COREOS_VERSION set and images exist, reuse existing.
If not set proceed with current legacy approach.

Also checks signatures after download.

Related to https://github.com/giantswarm/giantswarm/issues/1696