### PR TITLE
amagon-rollback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:26
+FROM fedora:24
 
 RUN dnf -y update && \
     dnf -y install net-tools libattr libattr-devel xfsprogs bridge-utils qemu-kvm  qemu-system-x86 qemu-img gpg && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -139,6 +139,7 @@ mkdir -p "${raw_cloud_config_dir}"
 cat "${CLOUD_CONFIG_PATH}" | base64 -d | gunzip > "${raw_cloud_config_path}"
 echo "hostname: '${HOSTNAME}'" >> "${raw_cloud_config_path}"
 
+#added PMU off to `-cpu host,pmu=off` https://github.com/giantswarm/k8s-kvm/pull/14
 exec $TASKSET /usr/bin/qemu-system-x86_64 \
   -name ${HOSTNAME} \
   -nographic \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -143,7 +143,7 @@ exec $TASKSET /usr/bin/qemu-system-x86_64 \
   -name ${HOSTNAME} \
   -nographic \
   -machine accel=kvm 
-  -cpu host \
+  -cpu host,pmu=off \
   -smp ${CORES} \
   -m ${MEMORY} \
   -enable-kvm \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -142,7 +142,7 @@ echo "hostname: '${HOSTNAME}'" >> "${raw_cloud_config_path}"
 exec $TASKSET /usr/bin/qemu-system-x86_64 \
   -name ${HOSTNAME} \
   -nographic \
-  -machine accel=kvm 
+  -machine accel=kvm \
   -cpu host,pmu=off \
   -smp ${CORES} \
   -m ${MEMORY} \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -142,22 +142,19 @@ echo "hostname: '${HOSTNAME}'" >> "${raw_cloud_config_path}"
 exec $TASKSET /usr/bin/qemu-system-x86_64 \
   -name ${HOSTNAME} \
   -nographic \
-  -machine accel=kvm -cpu host -smp ${CORES} \
+  -machine accel=kvm 
+  -cpu host \
+  -smp ${CORES} \
   -m ${MEMORY} \
   -enable-kvm \
   -device virtio-net-pci,netdev=${NETWORK_TAP_NAME} \
-  -netdev tap,id=${NETWORK_TAP_NAME},br=${NETWORK_BRIDGE_NAME},ifname=${NETWORK_TAP_NAME},downscript=no \
-  -fsdev \
-  local,id=conf,security_model=none,readonly,path=/usr/code/cloudconfig \
+  -netdev tap,id=${NETWORK_TAP_NAME},ifname=${NETWORK_TAP_NAME},downscript=no \
+  -fsdev local,id=conf,security_model=none,readonly,path=/usr/code/cloudconfig \
   -device virtio-9p-pci,fsdev=conf,mount_tag=config-2 \
   $ETCD_DATA_VOLUME_PATH \
-  -drive \
-  if=virtio,file=$USRFS,format=raw,serial=usr.readonly \
-  -drive \
-  if=virtio,file=$ROOTFS,format=raw,discard=on,serial=rootfs \
-  -device \
-  sga \
+  -drive if=virtio,file=$USRFS,format=raw,serial=usr.readonly \
+  -drive if=virtio,file=$ROOTFS,format=raw,discard=on,serial=rootfs \
+  -device sga \
   -serial mon:stdio \
-  -kernel \
-  $KERNEL \
+  -kernel $KERNEL \
   -append "console=ttyS0 root=/dev/disk/by-id/virtio-rootfs rootflags=rw mount.usr=/dev/disk/by-id/virtio-usr.readonly mount.usrflags=ro"


### PR DESCRIPTION
amagon rollback to fedora 24

ATM we have a problem on new `amagon` on-prem which causes `qemu` to kernel panic  with` virtio` drivers (affect net drivers, file disk drivers, `virtfs` path disk driver)

there is only one change - adding `pmu=off` to `-cpu host,pmu=off` as new version `qemu` is forcing it and exiting if the CPU performance counters are not available ( and amagon cant enable it)

there is also removing option `br=` from `-netdev tap` as its not supported in older qemu. (but still works ok)

the rest is just graphical change so it has  a logical  order (argument and its value on same line)