### PR TITLE
Adds virtio rng device to improve guest entropy

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -161,6 +161,7 @@ exec $TASKSET /usr/bin/qemu-system-x86_64 \
   -drive if=virtio,file=$USRFS,format=raw,serial=usr.readonly \
   -drive if=virtio,file=$ROOTFS,format=raw,discard=on,serial=rootfs \
   -device sga \
+  -device virtio-rng-pci \
   -serial stdio \
   -monitor unix:/qemu-monitor,server,nowait \
   -kernel $KERNEL \


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3593

See https://wiki.qemu.org/Features/VirtIORNG

We fixed this in vodafone on-prem back in the day (see https://github.com/giantswarm/k8s-vm/commit/29618a862fdd0f7ee058ee4ab2fb5cdbfd999bf0), but it was in the `vodafone-master` branch, and didn't make the jump to `k8s-kvm`. So, backporting, basically :D