### PR TITLE
Remove static 60s sleep and simplify while condition

### DIFF
--- a/qemu-shutdown
+++ b/qemu-shutdown
@@ -1,16 +1,12 @@
 #!/bin/bash
 
-# TODO: Remove this when shutdown-deferrer is fully implemented and returns
-# proper defer status.
-sleep 60
-
 POLL_INTERVAL=5
 POLL_TIMEOUT=600
 
 # Poll shutdown-deferrer service in order to wait for proper node draining
 # before VM shutdown.
-DEFER="yes"
-while [ "$DEFER" != "no" -a "$DEFER" != "false" -a $POLL_TIMEOUT -gt 0 ]
+DEFER="true"
+while [ "$DEFER" = "true" -a $POLL_TIMEOUT -gt 0 ]
 do
     sleep $POLL_INTERVAL
     DEFER=$(/usr/bin/curl -qsS http://127.0.0.1:60080/v1/defer/)

--- a/qemu-shutdown
+++ b/qemu-shutdown
@@ -7,7 +7,7 @@ then
 fi
 
 poll_interval=5
-poll_timeout=600
+poll_timeout=120
 shutdown_deferrer_url=$1
 
 # Poll shutdown-deferrer service in order to wait for proper node draining

--- a/qemu-shutdown
+++ b/qemu-shutdown
@@ -1,17 +1,24 @@
 #!/bin/bash
 
-POLL_INTERVAL=5
-POLL_TIMEOUT=600
+if [ $# -eq 0 ]
+then
+    echo "usage: $0 <shutdown-deferrer url>"
+    exit 1
+fi
+
+poll_interval=5
+poll_timeout=600
+shutdown_deferrer_url=$1
 
 # Poll shutdown-deferrer service in order to wait for proper node draining
 # before VM shutdown.
-DEFER="true"
-while [ "$DEFER" = "true" -a $POLL_TIMEOUT -gt 0 ]
+defer="true"
+while [ "$defer" = "true" -a $poll_timeout -gt 0 ]
 do
-    sleep $POLL_INTERVAL
-    DEFER=$(/usr/bin/curl -qsS http://127.0.0.1:60080/v1/defer/)
-    echo "GET /v1/defer: $DEFER"
-    POLL_TIMEOUT=$(/bin/expr $POLL_TIMEOUT - $POLL_INTERVAL)
+    sleep $poll_interval
+    defer=$(/usr/bin/curl -qsS $shutdown_deferrer_url)
+    echo "GET /v1/defer: $defer"
+    poll_timeout=$(/bin/expr $poll_timeout - $poll_interval)
 done
 
 # Send graceful shutdown command to qemu monitor.

--- a/qemu-shutdown
+++ b/qemu-shutdown
@@ -29,3 +29,5 @@ while [ -S /qemu-monitor ]
 do
   sleep 0.1
 done
+
+exit 0


### PR DESCRIPTION
Now that shutdown-deferrer returns proper defer status, static 60s wait
can be removed from shutdown. Once node in question has been drained,
shutdown-deferrer returns "false" and polling loop breaks and node can
be terminated.

Also simplifies while loop condition and takes shutdown-deferrer address as a parameter.

Towards https://github.com/giantswarm/giantswarm/issues/2993#issuecomment-429270302