### PR TITLE
fix-kubelet-volume

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -117,7 +117,7 @@ fi
 # Prepare root FS.
 #
 
-rm -f ${ROOTFS} ${DOCKERFS}
+rm -f ${ROOTFS} ${DOCKERFS} ${KUBELETFS}
 truncate -s ${DISK_OS} ${ROOTFS}
 mkfs.xfs ${ROOTFS}
 truncate -s ${DISK_DOCKER} ${DOCKERFS}


### PR DESCRIPTION
a bug that I introduced when adding kubelet volumes

without removing the volume file first, the  `docker-entrypoint` script will fail  to start in a situation when the container was restarted by kubelet ( ie: liveness probe check fails)