### PR TITLE
ignition-migration-fix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2019 Giant Swarm GmbH
+   Copyright 2016 - 2019 Giant Swarm GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -64,7 +64,7 @@ MAC_ADDRESS=$(printf 'DE:AD:BE:%02X:%02X:%02X\n' $((RANDOM % 256)) $((RANDOM % 2
 # Prepare CoreOS images.
 #
 
-IMGDIR="/usr/code/images"
+IMGDIR="/usr/code/images/v2"
 KERNEL="${IMGDIR}/coreos_production_pxe.vmlinuz"
 INITRD="${IMGDIR}/coreos_production_pxe_image.cpio.gz"
 
@@ -77,7 +77,7 @@ if [ ! -z ${COREOS_VERSION+x} ] && [ ! -z "${COREOS_VERSION}" ]; then
   INITRD="${IMGDIR}/${COREOS_VERSION}/coreos_production_pxe_image.cpio.gz"
 
   # Download if does not exist.
-  if [ ! -f "${IMGDIR}/${COREOS_VERSION}/migration.lock" ] || [ ! -f "${IMGDIR}/${COREOS_VERSION}/done.lock" ]; then
+  if [ ! -f "${IMGDIR}/${COREOS_VERSION}/done.lock" ]; then
 
     # Prepare directory for images.
     rm -rf ${IMGDIR}/${COREOS_VERSION}
@@ -100,7 +100,7 @@ if [ ! -z ${COREOS_VERSION+x} ] && [ ! -z "${COREOS_VERSION}" ]; then
     rm -f coreos_production_pxe_image.cpio.gz.sig
 
     # Create lock.
-    touch done.lock; touch migration.lock; cd -
+    touch done.lock; cd -
   fi
 else
 	echo "ERROR: COREOS_VERSION env not set."


### PR DESCRIPTION
with the current state, there can be a race condition when  there are running k8s-kvm from cloud-config and ignition on the same machine with same CoreOS version

Ignition would delete old files and old `k8s-kvm` pods wonts start as they are missing squash files

Versioning image directories sounds like a better solution here as dirs for cloudconfig and ignition will be separate and won't influence each other and in future, we can easily add another version in the future if necessary.

We might have few copies of CoreOS images but that should not be a big issue.