### PR TITLE
Updates to Fedora 30 and updates all packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-FROM fedora:29
+FROM fedora:30
 
 RUN dnf -y update && \
     dnf -y install \
-        bridge-utils-1.6-2.fc29 \
-        e2fsprogs-1.44.4-1.fc29 \
-        gnupg-1.4.23-2.fc29 \
-        iproute-4.20.0-1.fc29 \
-        libattr-2.4.48-3.fc29 \
-        libattr-devel-2.4.48-3.fc29 \
-        net-tools-2.0-0.53.20160912git.fc29 \
-        qemu-img-3.0.0-4.fc29 \
-        qemu-kvm-3.0.0-4.fc29 \
-        qemu-system-x86-3.0.0-4.fc29 \
-        socat-1.7.3.2-7.fc29 \
-        xfsprogs-4.17.0-3.fc29 \
+        bridge-utils-1.6-3.fc30 \
+        e2fsprogs-1.44.6-1.fc30 \
+        gnupg2-2.2.13-1.fc30 \
+        iproute-5.0.0-2.fc30 \
+        libattr-2.4.48-5.fc30 \
+        libattr-devel-2.4.48-5.fc30 \
+        net-tools-2.0-0.54.20160912git.fc30 \
+        qemu-img-3.1.0-6.fc30 \
+        qemu-kvm-3.1.0-6.fc30 \
+        qemu-system-x86-3.1.0-6.fc30 \
+        socat-1.7.3.2-9.fc30 \
+        xfsprogs-4.19.0-4.fc30 \
     && dnf clean all
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5730

As part of debugging and hunting down the ext4 corruption issues,
we thought it would make sense to update the k8s-kvm image,
in case of bug fixes.