### PR TITLE
Revert docker/kubelet volume to XFS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM fedora:30
 RUN dnf -y update && \
     dnf -y install \
         bridge-utils-1.6-3.fc30 \
-        e2fsprogs-1.44.6-1.fc30 \
         gnupg2-2.2.13-1.fc30 \
         iproute-5.0.0-2.fc30 \
         libattr-2.4.48-5.fc30 \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -116,9 +116,9 @@ rm -f ${ROOTFS} ${DOCKERFS} ${KUBELETFS}
 truncate -s ${DISK_OS} ${ROOTFS}
 mkfs.xfs ${ROOTFS}
 truncate -s ${DISK_DOCKER} ${DOCKERFS}
-mkfs.ext4 ${DOCKERFS}
+mkfs.xfs ${DOCKERFS}
 truncate -s ${DISK_KUBELET} ${KUBELETFS}
-mkfs.ext4 ${KUBELETFS}
+mkfs.xfs ${KUBELETFS}
 
 #
 # Ensure proper mounts.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5730

We have a theory that XFS shows the (currently unknown) underlying
error better than ext4 (via the kernel issue when under OOM situation).
To that end, this PR reverts us to XFS, to test newer QEMU version.