### PR TITLE
Move to Flatcar

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -66,16 +66,16 @@ MAC_ADDRESS=$(printf 'DE:AD:BE:%02X:%02X:%02X\n' $((RANDOM % 256)) $((RANDOM % 2
 #
 
 IMGDIR="/usr/code/images/v2"
-KERNEL="${IMGDIR}/coreos_production_pxe.vmlinuz"
-INITRD="${IMGDIR}/coreos_production_pxe_image.cpio.gz"
+KERNEL="${IMGDIR}/flatcar_production_pxe.vmlinuz"
+INITRD="${IMGDIR}/flatcar_production_pxe_image.cpio.gz"
 
 mkdir -p ${IMGDIR}
 
 # Use specific CoreOS version, if ${COREOS_VERSION} is set and not empty.
 # Check if images already in place, if not download them.
 if [ ! -z ${COREOS_VERSION+x} ] && [ ! -z "${COREOS_VERSION}" ]; then
-  KERNEL="${IMGDIR}/${COREOS_VERSION}/coreos_production_pxe.vmlinuz"
-  INITRD="${IMGDIR}/${COREOS_VERSION}/coreos_production_pxe_image.cpio.gz"
+  KERNEL="${IMGDIR}/${COREOS_VERSION}/flatcar_production_pxe.vmlinuz"
+  INITRD="${IMGDIR}/${COREOS_VERSION}/flatcar_production_pxe_image.cpio.gz"
 
   # Download if does not exist.
   if [ ! -f "${IMGDIR}/${COREOS_VERSION}/done.lock" ]; then
@@ -85,14 +85,14 @@ if [ ! -z ${COREOS_VERSION+x} ] && [ ! -z "${COREOS_VERSION}" ]; then
     mkdir -p ${IMGDIR}/${COREOS_VERSION}; cd ${IMGDIR}/${COREOS_VERSION}
 
     # Download images.
-    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/2219.99.1/flatcar_production_pxe.vmlinuz
-    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/2219.99.1/flatcar_production_pxe_image.cpio.gz
+    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/${COREOS_VERSION}/flatcar_production_pxe.vmlinuz
+    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/${COREOS_VERSION}/flatcar_production_pxe_image.cpio.gz
 
     # Check the signatures after download.
     # XXX: Assume local storage is trusted, do not check everytime pod starts.
     curl --fail -s https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc | gpg --import -
-    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/2219.99.1/flatcar_production_pxe.vmlinuz.sig
-    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/2219.99.1/flatcar_production_pxe_image.cpio.gz.sig
+    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/${COREOS_VERSION}/flatcar_production_pxe.vmlinuz.sig
+    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/${COREOS_VERSION}/flatcar_production_pxe_image.cpio.gz.sig
     gpg --verify flatcar_production_pxe.vmlinuz.sig
     gpg --verify flatcar_production_pxe_image.cpio.gz.sig
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -176,7 +176,7 @@ exec $TASKSET /usr/bin/qemu-system-x86_64 \
   -enable-kvm \
   -device virtio-net-pci,netdev=${NETWORK_TAP_NAME},mac=${MAC_ADDRESS} \
   -netdev tap,id=${NETWORK_TAP_NAME},ifname=${NETWORK_TAP_NAME},downscript=no \
-  -fw_cfg name=opt/com.coreos/config,file=${raw_ignition_dir}/final.json \
+  -fw_cfg name=opt/org.flatcar-linux/config,file=${raw_ignition_dir}/final.json \
   -drive if=none,file=${ROOTFS},format=raw,discard=on,id=rootfs \
   -device virtio-blk-pci,drive=rootfs,serial=rootfs \
   -drive if=none,file=${DOCKERFS},format=raw,discard=on,id=dockerfs \
@@ -190,4 +190,4 @@ exec $TASKSET /usr/bin/qemu-system-x86_64 \
   -monitor unix:/qemu-monitor,server,nowait \
   -kernel $KERNEL \
   -initrd $INITRD \
-  -append "console=ttyS0 root=/dev/disk/by-id/virtio-rootfs rootflags=rw coreos.first_boot=1"
+  -append "console=ttyS0 root=/dev/disk/by-id/virtio-rootfs rootflags=rw flatcar.first_boot=1"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -176,7 +176,7 @@ exec $TASKSET /usr/bin/qemu-system-x86_64 \
   -enable-kvm \
   -device virtio-net-pci,netdev=${NETWORK_TAP_NAME},mac=${MAC_ADDRESS} \
   -netdev tap,id=${NETWORK_TAP_NAME},ifname=${NETWORK_TAP_NAME},downscript=no \
-  -fw_cfg name=opt/org.flatcar-linux/config,file=${raw_ignition_dir}/final.json \
+  -fw_cfg name=opt/com.coreos/config,file=${raw_ignition_dir}/final.json \
   -drive if=none,file=${ROOTFS},format=raw,discard=on,id=rootfs \
   -device virtio-blk-pci,drive=rootfs,serial=rootfs \
   -drive if=none,file=${DOCKERFS},format=raw,discard=on,id=dockerfs \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -85,20 +85,20 @@ if [ ! -z ${COREOS_VERSION+x} ] && [ ! -z "${COREOS_VERSION}" ]; then
     mkdir -p ${IMGDIR}/${COREOS_VERSION}; cd ${IMGDIR}/${COREOS_VERSION}
 
     # Download images.
-    curl --fail -O http://stable.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe.vmlinuz
-    curl --fail -O http://stable.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe_image.cpio.gz
+    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/2219.99.1/flatcar_production_pxe.vmlinuz
+    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/2219.99.1/flatcar_production_pxe_image.cpio.gz
 
     # Check the signatures after download.
     # XXX: Assume local storage is trusted, do not check everytime pod starts.
-    curl --fail -s https://coreos.com/security/image-signing-key/CoreOS_Image_Signing_Key.asc | gpg --import -
-    curl --fail -O http://stable.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe.vmlinuz.sig
-    curl --fail -O http://stable.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe_image.cpio.gz.sig
-    gpg --verify coreos_production_pxe.vmlinuz.sig
-    gpg --verify coreos_production_pxe_image.cpio.gz.sig
+    curl --fail -s https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc | gpg --import -
+    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/2219.99.1/flatcar_production_pxe.vmlinuz.sig
+    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/2219.99.1/flatcar_production_pxe_image.cpio.gz.sig
+    gpg --verify flatcar_production_pxe.vmlinuz.sig
+    gpg --verify flatcar_production_pxe_image.cpio.gz.sig
 
     # Do cleanup.
-    rm -f coreos_production_pxe.vmlinuz.sig
-    rm -f coreos_production_pxe_image.cpio.gz.sig
+    rm -f flatcar_production_pxe.vmlinuz.sig
+    rm -f flatcar_production_pxe_image.cpio.gz.sig
 
     # Create lock.
     touch done.lock; cd -

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,16 +14,24 @@
 #     ${NTP_SERVERS}            e.g. "0.coreos.pool.ntp.org,1.coreos.pool.ntp.org"
 #     ${ROLE}                   e.g. "master" or "worker"
 #     ${CLOUD_CONFIG_PATH}      e.g. "/cloudconfig/user_data"
-#     ${COREOS_VERSION}         e.g. "1409.7.0"
-#     ${FLATCAR_LINUX}          e.g. "0" or "1"
+#     ${FLATCAR_VERSION}        e.g. "1409.7.0"
+#     ${FLATCAR_CHANNEL}        e.g. "alpha"
+#     ${DEBUG}                  e.g. "true"
 
 set -eu
 
-raw_ignition_dir="/usr/code/ignition"
+if [ "${DEBUG:-}" == "true" ]; then
+  set -vx
+fi
 
-if [ -z ${CLOUD_CONFIG_PATH} ]; then
-    echo "CLOUD_CONFIG_PATH must be set." >&2
-    exit 1
+if [ -z "${CLOUD_CONFIG_PATH}" ]; then
+  echo "CLOUD_CONFIG_PATH must be set." >&2
+  exit 1
+fi
+
+if [ -z "${FLATCAR_VERSION}" ]; then
+  echo "FLATCAR_VERSION must be set." >&2
+  exit 1
 fi
 
 #
@@ -33,8 +41,8 @@ fi
 NETWORK_BRIDGE_IP=""
 
 while :; do
-  NETWORK_BRIDGE_IP=$(/sbin/ifconfig ${NETWORK_BRIDGE_NAME} | grep 'inet ' | awk '{print $2}' | cut -d ':' -f 2)
-  if [ ! -z "${NETWORK_BRIDGE_IP}" ]; then
+  NETWORK_BRIDGE_IP=$(/sbin/ifconfig "$NETWORK_BRIDGE_NAME" | grep 'inet ' | awk '{print $2}' | cut -d ':' -f 2)
+  if [ -n "$NETWORK_BRIDGE_IP" ]; then
     break
   fi
   echo "Waiting for ip address on interface ${NETWORK_BRIDGE_NAME}."
@@ -53,83 +61,70 @@ echo "allow ${NETWORK_BRIDGE_NAME}" >/etc/qemu/bridge.conf
 # Prepare FS.
 #
 
+RAW_IGNITION_DIR="/usr/code/ignition"
+
 mkdir -p /usr/code/rootfs/
-mkdir -p ${raw_ignition_dir}
+mkdir -p $RAW_IGNITION_DIR
+
+#
+# Prepare Flatcar images.
+#
+
+IMGDIR="/usr/code/images/v2"
+KERNEL="flatcar_production_pxe.vmlinuz"
+INITRD="flatcar_production_pxe_image.cpio.gz"
+FLATCAR_CHANNEL=${FLATCAR_CHANNEL:-stable}
+
+mkdir -p ${IMGDIR}
+
+# Check if images already in place, if not download them.
+# Download if does not exist.
+if [ ! -f "${IMGDIR}/${FLATCAR_VERSION}/done.lock" ]; then
+  # Prepare directory for images.
+  rm -rf "${IMGDIR:?}"/"${FLATCAR_VERSION}"
+  mkdir -p "${IMGDIR}"/"${FLATCAR_VERSION}"
+  cd ${IMGDIR}/"${FLATCAR_VERSION}"
+
+  # Download images.
+  curl --fail -O https://"$FLATCAR_CHANNEL".release.flatcar-linux.net/amd64-usr/"$FLATCAR_VERSION"/$KERNEL
+  curl --fail -O https://"$FLATCAR_CHANNEL".release.flatcar-linux.net/amd64-usr/"$FLATCAR_VERSION"/$INITRD
+
+  # Check the signatures after download.
+  # XXX: Assume local storage is trusted, do not check everytime pod starts.
+  curl --fail -s https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc | gpg --import -
+  curl --fail -O https://"$FLATCAR_CHANNEL".release.flatcar-linux.net/amd64-usr/"$FLATCAR_VERSION"/$KERNEL.sig
+  curl --fail -O https://"$FLATCAR_CHANNEL".release.flatcar-linux.net/amd64-usr/"$FLATCAR_VERSION"/$INITRD.sig
+  gpg --verify ${KERNEL}.sig
+  gpg --verify ${INITRD}.sig
+
+  # Do cleanup.
+  rm -f $KERNEL.sig
+  rm -f $INITRD.sig
+
+  # Create lock.
+  touch done.lock
+  cd -
+fi
+
+KERNEL="${IMGDIR}/${FLATCAR_VERSION}/${KERNEL}"
+INITRD="${IMGDIR}/${FLATCAR_VERSION}/${INITRD}"
+
+#
+# Prepare root FS.
+#
 
 ROOTFS="/usr/code/rootfs/rootfs.img"
 DOCKERFS="/usr/code/rootfs/dockerfs.img"
 KUBELETFS="/usr/code/rootfs/kubeletfs.img"
 MAC_ADDRESS=$(printf 'DE:AD:BE:%02X:%02X:%02X\n' $((RANDOM % 256)) $((RANDOM % 256)) $((RANDOM % 256)))
 
-
-#
-# Prepare CoreOS images.
-#
-
-IMGDIR="/usr/code/images/v2"
-KERNEL="coreos_production_pxe.vmlinuz"
-INITRD="coreos_production_pxe_image.cpio.gz"
-FIRST_BOOT_FLAG="coreos.first_boot"
-
-if [ "$FLATCAR_LINUX" = "1" ]; then
-  KERNEL="flatcar_production_pxe.vmlinuz"
-  INITRD="flatcar_production_pxe_image.cpio.gz"
-  FIRST_BOOT_FLAG="flatcar.first_boot"
-fi
-
-mkdir -p ${IMGDIR}
-
-# Use specific CoreOS version, if ${COREOS_VERSION} is set and not empty.
-# Check if images already in place, if not download them.
-if [ ! -z ${COREOS_VERSION+x} ] && [ ! -z "${COREOS_VERSION}" ]; then
-  # Download if does not exist.
-  if [ ! -f "${IMGDIR}/${COREOS_VERSION}/done.lock" ]; then
-
-    # Prepare directory for images.
-    rm -rf ${IMGDIR}/${COREOS_VERSION}
-    mkdir -p ${IMGDIR}/${COREOS_VERSION}; cd ${IMGDIR}/${COREOS_VERSION}
-
-    # Download images.
-    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/${COREOS_VERSION}/${KERNEL}
-    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/${COREOS_VERSION}/${INITRD}
-
-    # Check the signatures after download.
-    # XXX: Assume local storage is trusted, do not check everytime pod starts.
-    curl --fail -s https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc | gpg --import -
-    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/${COREOS_VERSION}/${KERNEL}
-    curl --fail -O https://edge.release.flatcar-linux.net/amd64-usr/${COREOS_VERSION}/${INITRD}
-    gpg --verify ${KERNEL}.sig
-    gpg --verify ${INITRD}.sig
-
-    # Do cleanup.
-    rm -f ${KERNEL}.sig
-    rm -f ${INITRD}.sig
-
-    # Create lock.
-    touch done.lock; cd -
-  fi
-
-  KERNEL="${COREOS_VERSION}/${KERNEL}"
-  INITRD="${COREOS_VERSION}/${INITRD}"
-else
-	echo "ERROR: COREOS_VERSION env not set."
-	exit 1
-fi
-
-KERNEL="${IMGDIR}/${KERNEL}"
-INITRD="${IMGDIR}/${INITRD}"
-
-#
-# Prepare root FS.
-#
-
-rm -f ${ROOTFS} ${DOCKERFS} ${KUBELETFS}
-truncate -s ${DISK_OS} ${ROOTFS}
-mkfs.xfs ${ROOTFS}
-truncate -s ${DISK_DOCKER} ${DOCKERFS}
-mkfs.xfs ${DOCKERFS}
-truncate -s ${DISK_KUBELET} ${KUBELETFS}
-mkfs.xfs ${KUBELETFS}
+rm -f $ROOTFS $DOCKERFS $KUBELETFS
+truncate -s "$DISK_OS" $ROOTFS
+mkfs.xfs $ROOTFS
+truncate -s "$DISK_DOCKER" $DOCKERFS
+mkfs.xfs $DOCKERFS
+truncate -s "$DISK_KUBELET" $KUBELETFS
+mkfs.xfs $KUBELETFS
 
 #
 # Ensure proper mounts.
@@ -145,9 +140,10 @@ fi
 # given.
 
 TASKSET=
+PIN_CPU=${PIN_CPU:-}
 
-if [ ! -z ${PIN_CPU+x} ] && [ ! -z "$PIN_CPU" ]; then
-  TASKSET="taskset -ac $PIN_CPU"
+if [ -n "$PIN_CPU" ]; then
+  TASKSET="taskset -ac ${PIN_CPU}"
 fi
 
 #
@@ -155,7 +151,7 @@ fi
 #
 
 # Extract ignition from mounted configmap into raw provision config.
-cat "${CLOUD_CONFIG_PATH}" | base64 -d | gunzip > "${raw_ignition_dir}/${ROLE}.json"
+base64 <"${CLOUD_CONFIG_PATH}" -d | gunzip >"$RAW_IGNITION_DIR/${ROLE}.json"
 
 # Generate final ignition with static network configuration and hostname
 # Configuration tool: https://github.com/giantswarm/qemu-node-setup
@@ -172,32 +168,32 @@ cat "${CLOUD_CONFIG_PATH}" | base64 -d | gunzip > "${raw_ignition_dir}/${ROLE}.j
 #        Colon separated list of NTP servers.
 #  -out string
 #        Path to save resulting ignition config.
-/qemu-node-setup -bridge-ip=${NETWORK_BRIDGE_IP} -dns-servers=${DNS_SERVERS} -hostname=${HOSTNAME} -main-config="${raw_ignition_dir}/${ROLE}.json" \
-                 -ntp-servers=${NTP_SERVERS} -out="${raw_ignition_dir}/final.json"
+/qemu-node-setup -bridge-ip="$NETWORK_BRIDGE_IP" -dns-servers="$DNS_SERVERS" -hostname="$HOSTNAME" -main-config="${RAW_IGNITION_DIR}/${ROLE}.json" \
+  -ntp-servers="${NTP_SERVERS}" -out="$RAW_IGNITION_DIR/final.json"
 
 #added PMU off to `-cpu host,pmu=off` https://github.com/giantswarm/k8s-kvm/pull/14
-exec $TASKSET /usr/bin/qemu-system-x86_64 \
-  -name ${HOSTNAME} \
+eval exec "$TASKSET" /usr/bin/qemu-system-x86_64 \
+  -name "$HOSTNAME" \
   -nographic \
   -machine type=q35,accel=kvm \
   -cpu host,pmu=off \
-  -smp ${CORES} \
-  -m ${MEMORY} \
+  -smp "$CORES" \
+  -m "$MEMORY" \
   -enable-kvm \
-  -device virtio-net-pci,netdev=${NETWORK_TAP_NAME},mac=${MAC_ADDRESS} \
-  -netdev tap,id=${NETWORK_TAP_NAME},ifname=${NETWORK_TAP_NAME},downscript=no \
-  -fw_cfg name=opt/com.coreos/config,file=${raw_ignition_dir}/final.json \
-  -drive if=none,file=${ROOTFS},format=raw,discard=on,id=rootfs \
+  -device virtio-net-pci,netdev="$NETWORK_TAP_NAME",mac="$MAC_ADDRESS" \
+  -netdev tap,id="$NETWORK_TAP_NAME",ifname="$NETWORK_TAP_NAME",downscript=no \
+  -fw_cfg name=opt/org.flatcar-linux/config,file="$RAW_IGNITION_DIR"/final.json \
+  -drive if=none,file="$ROOTFS",format=raw,discard=on,id=rootfs \
   -device virtio-blk-pci,drive=rootfs,serial=rootfs \
-  -drive if=none,file=${DOCKERFS},format=raw,discard=on,id=dockerfs \
+  -drive if=none,file="$DOCKERFS",format=raw,discard=on,id=dockerfs \
   -device virtio-blk-pci,drive=dockerfs,serial=dockerfs \
-  -drive if=none,file=${KUBELETFS},format=raw,discard=on,id=kubeletfs \
+  -drive if=none,file="$KUBELETFS",format=raw,discard=on,id=kubeletfs \
   -device virtio-blk-pci,drive=kubeletfs,serial=kubeletfs \
-  $ETCD_DATA_VOLUME_PATH \
+  "$ETCD_DATA_VOLUME_PATH" \
   -device sga \
   -device virtio-rng-pci \
   -serial stdio \
   -monitor unix:/qemu-monitor,server,nowait \
-  -kernel $KERNEL \
-  -initrd $INITRD \
-  -append "console=ttyS0 root=/dev/disk/by-id/virtio-rootfs rootflags=rw ${FIRST_BOOT_FLAG}=1"
+  -kernel "$KERNEL" \
+  -initrd "$INITRD" \
+  -append "\"console=ttyS0 root=/dev/disk/by-id/virtio-rootfs rootflags=rw flatcar.first_boot=1\""


### PR DESCRIPTION
Container Linux is not going to be supported in the future and is stuck with Docker 18.6, probably forever. This PR adds a flag to `k8s-kvm` docker container to allow a Flatcar qemu image to be used instead of Container Linux.

The Flatcar channel is currently set to edge so this can be used for testing new versions of Docker (18.9+) and Linux Kernel (5+) which are still at parity with Container Linux in the stable/beta/alpha channels.

I am creating a PR for this so the work isn't lost. If we're not using it in production, it could be argued that this shouldn't be merged to `master`, but I think it could have value for testing and future migration.

----

Updated 25.02.2020 @mazzy89 

Towards https://github.com/giantswarm/giantswarm/issues/8553

* Remove CoreOS references
* Add Flatcar env variables
  * `FLATCAR_CHANNEL`
  * `FLATCAR_VERSION`
* Add a `DEBUG` env - useful to debug the behavior of the script
* Polish the script
 * Run `shellcheck` and apply all the recommendations 

This has been tested in the KVM operator running **alpha** channel with **2303.4.0** version
