### PR TITLE
reference the bridge name whilst waiting for the IP

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,7 +36,7 @@ while :; do
   if [ ! -z "${NETWORK_BRIDGE_IP}" ]; then
     break
   fi
-  echo "Waiting for ip address on interface ${NETWORK_BRIDGE_IP}."
+  echo "Waiting for ip address on interface ${NETWORK_BRIDGE_NAME}."
   sleep 1
 done
 


### PR DESCRIPTION
Just a small bit of housekeeping to make sure the message is correct on container startup.