### PR TITLE
Use new Flatcar GPG URL and follow redirects

### DIFF
--- a/.github/workflows/zz_generated.gitleaks.yaml
+++ b/.github/workflows/zz_generated.gitleaks.yaml
@@ -14,4 +14,4 @@ jobs:
       with:
         fetch-depth: '0'
     - name: gitleaks-action
-      uses: zricethezav/gitleaks-action@v1.1.4
+      uses: zricethezav/gitleaks-action@v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Change to new Flatcar GPG signing key and follow redirects.
+
 ### Changed
 
 - Switch from Fedora 32 to Fedora 33 (qemu 4.2.0 -> 5.0.0).

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -91,7 +91,7 @@ if [ ! -f "${IMGDIR}/${FLATCAR_VERSION}/done.lock" ]; then
 
   # Check the signatures after download.
   # XXX: Assume local storage is trusted, do not check everytime pod starts.
-  curl --fail -s https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc | gpg --import -
+  curl --fail -sL https://kinvolk.io/flatcar-container-linux/security/image-signing-key/Flatcar_Image_Signing_Key.asc | gpg --import -
   curl --fail -O https://"$FLATCAR_CHANNEL".release.flatcar-linux.net/amd64-usr/"$FLATCAR_VERSION"/$KERNEL.sig
   curl --fail -O https://"$FLATCAR_CHANNEL".release.flatcar-linux.net/amd64-usr/"$FLATCAR_VERSION"/$INITRD.sig
   gpg --verify ${KERNEL}.sig


### PR DESCRIPTION
https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc redirects to https://kinvolk.io/flatcar-container-linux/security/image-signing-key/Flatcar_Image_Signing_Key.asc now, but we don't follow redirects when downloading GPG key.