### PR TITLE
Use new Flatcar GPG URL and follow redirects

### DIFF
--- a/.github/workflows/zz_generated.create_release.yaml
+++ b/.github/workflows/zz_generated.create_release.yaml
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@4.2.1
+#    devctl@4.3.0
 #
 name: Create Release
 on:

--- a/.github/workflows/zz_generated.create_release_pr.yaml
+++ b/.github/workflows/zz_generated.create_release_pr.yaml
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@4.2.1
+#    devctl@4.3.0
 #
 name: Create Release PR
 on:

--- a/.github/workflows/zz_generated.gitleaks.yaml
+++ b/.github/workflows/zz_generated.gitleaks.yaml
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@4.2.1
+#    devctl@4.3.0
 #
 name: gitleaks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Change to new Flatcar GPG signing key and follow redirects.
+
 ## [0.4.0] - 2021-02-04
 
 ### Changed

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -92,7 +92,7 @@ if [ ! -f "${IMGDIR}/${FLATCAR_VERSION}/done.lock" ]; then
 
   # Check the signatures after download.
   # XXX: Assume local storage is trusted, do not check everytime pod starts.
-  curl --fail -s https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc | gpg --import -
+  curl --fail -sL https://kinvolk.io/flatcar-container-linux/security/image-signing-key/Flatcar_Image_Signing_Key.asc | gpg --import -
   curl --fail -O https://"$FLATCAR_CHANNEL".release.flatcar-linux.net/amd64-usr/"$FLATCAR_VERSION"/$KERNEL.sig
   curl --fail -O https://"$FLATCAR_CHANNEL".release.flatcar-linux.net/amd64-usr/"$FLATCAR_VERSION"/$INITRD.sig
   gpg --verify ${KERNEL}.sig


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15734

https://www.flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.asc redirects to https://kinvolk.io/flatcar-container-linux/security/image-signing-key/Flatcar_Image_Signing_Key.asc now, but we don't follow redirects when downloading GPG key.