### PR TITLE
Support ignition from file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.7.0
+  architect: giantswarm/architect@3.3.0
 
 workflows:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine AS build
+FROM golang:1.16-alpine AS build
 
 ENV GO111MODULE=on
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -223,7 +223,10 @@ func parseIgnitionConfig() (string, error) {
 
 	// Decode data according to format flag
 	if ignitionData == nil {
+		fmt.Println("no ignition found")
 		return "", nil
+	} else {
+		fmt.Println("read ignition", len(ignitionData))
 	}
 
 	var base64Encoded bool
@@ -242,17 +245,15 @@ func parseIgnitionConfig() (string, error) {
 	}
 
 	if base64Encoded {
-		decodedLen := base64.StdEncoding.DecodedLen(len(ignitionData))
-		decoded := make([]byte, decodedLen)
-		_, err = base64.StdEncoding.Decode(decoded, ignitionData)
+		fmt.Println("decoding base64 ignition", len(ignitionData))
+		ignitionData, err = base64.StdEncoding.DecodeString(string(ignitionData))
 		if err != nil {
 			return "", fmt.Errorf("decoding ignition as base64 failed: %w", err)
 		}
-
-		ignitionData = decoded
 	}
 
 	if compressed {
+		fmt.Println("unzipping ignition", len(ignitionData))
 		byteReader := bytes.NewReader(ignitionData)
 		zippedReader, err := gzip.NewReader(byteReader)
 		if err != nil {

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -225,8 +225,6 @@ func parseIgnitionConfig() (string, error) {
 	if ignitionData == nil {
 		fmt.Println("no ignition found")
 		return "", nil
-	} else {
-		fmt.Println("read ignition", len(ignitionData))
 	}
 
 	var base64Encoded bool
@@ -245,7 +243,6 @@ func parseIgnitionConfig() (string, error) {
 	}
 
 	if base64Encoded {
-		fmt.Println("decoding base64 ignition", len(ignitionData))
 		ignitionData, err = base64.StdEncoding.DecodeString(string(ignitionData))
 		if err != nil {
 			return "", fmt.Errorf("decoding ignition as base64 failed: %w", err)
@@ -253,7 +250,6 @@ func parseIgnitionConfig() (string, error) {
 	}
 
 	if compressed {
-		fmt.Println("unzipping ignition", len(ignitionData))
 		byteReader := bytes.NewReader(ignitionData)
 		zippedReader, err := gzip.NewReader(byteReader)
 		if err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16594

Containervmm was designed to accept ignition as a base64-encoded flag, but ignition JSON for KVM clusters is too large to be passed as a flag (10s of KBs) so it must be a file instead.